### PR TITLE
add bitbucket remote

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -16,6 +16,7 @@ inherits(Resolver, EventEmitter)
 // more will be added as we support them.
 Resolver.remotes = [
   'github',
+  'bitbucket',
 ];
 
 /**


### PR DESCRIPTION
Corresponds to added bitbucket remote in https://github.com/component/remotes.js/pull/14

Left trailing comma as it was there before, complying with styles
