### PR TITLE
Adding some cogent options for remotes

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -62,7 +62,8 @@ function Resolver(root, options) {
       out: this.out,
       // we check local components by default
       local: options.local !== false,
-      timeout: options.timeout || null
+      timeout: options.timeout || null,
+      retries: options.retries || null
     });
     debug('remote not set - defaulting to remotes\'s defaults');
   }


### PR DESCRIPTION
This adds the ability to change the cogent `timeout` value for remotes, it takes `options.timeout` if it's available. (if not, nothing changes)

When github has slowness, 5000ms is not hard to hit. (and once it does, that's a show-stopper) I'd like to be able to push that value up higher as-needed. (could probably even add a cli flag, or just raise the default)

I've also added `retries` to the mix, as playing around with some of these options has really helped us out.
