### PR TITLE
Pinning regenerator to v0.4.6 because of a breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "co": "^3"
   },
   "devDependencies": {
-    "rimraf": "^2.2.5",
-    "mocha": "^1.17.0",
-    "should": "^3.0.0",
     "gnode": "0",
-    "regenerator": "0"
+    "mocha": "^1.17.0",
+    "regenerator": "^0.4.6",
+    "rimraf": "^2.2.5",
+    "should": "^3.0.0"
   },
   "scripts": {
     "test": "NODE=gnode make test",


### PR DESCRIPTION
The current/latest version (1.1.2) of resolver.js is broken at the moment. The regenerator library has a change in it's latest version (0.4.7) that breaks something. (see #15) I've pinned to 0.4.6 here, this will need to be merged and a new version of component-resolver should be pushed asap.
