### PR TITLE
test: Add a (failing) test for resolving component/levenshtein

### DIFF
--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -114,6 +114,16 @@ describe('Dependencies', function () {
     hgp.dependencies['component/classes'].should.be.ok
   }))
 
+  it('should work with component/levenshtein', co(function* () {
+    var tree = yield* resolve({
+      dependencies: {
+        'component/levenshtein': '*'
+      }
+    })
+
+    tree.dependencies['component/levenshtein'].should.be.ok
+  }))
+
   it('should work with ianstormtaylor/router', co(function* () {
     var tree = yield* resolve({
       dependencies: {


### PR DESCRIPTION
```
 1) Dependencies should work with component/levenshtein:
     Error: no remote found for dependency "component/levenshtein@v0.0.1". run `component open troubleshooting` for help.
      at Resolver.<anonymous> (/Users/stephenmathieson/repos/resolver.js/build/dependencies.js:504:13)
      at Generator.invoke (evalmachine.<anonymous>:141:31)
      at Generator.invoke (evalmachine.<anonymous>:79:50)
      at next (/Users/stephenmathieson/repos/resolver.js/node_modules/co/index.js:83:21)
      at /Users/stephenmathieson/repos/resolver.js/node_modules/co/index.js:102:18
      at Gunzip.onEnd (/Users/stephenmathieson/repos/resolver.js/node_modules/cogent/node_modules/raw-body/index.js:117:7)
      at Gunzip.g (events.js:180:16)
      at Gunzip.EventEmitter.emit (events.js:117:20)
      at _stream_readable.js:919:16
      at process._tickCallback (node.js:419:13)
```
