### PR TITLE
Support for a proxy by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The main `options` are:
     - `semver: 1`
     - `installs: 5`
     - `downloads: 1`
+- `proxy` - specify a proxy to use, or try to fallback to the environments https_proxy.
 
 Options passed to `component-downloader`:
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -63,7 +63,8 @@ function Resolver(root, options) {
       // we check local components by default
       local: options.local !== false,
       timeout: options.timeout || null,
-      retries: options.retries || null
+      retries: options.retries || null,
+      proxy: options.proxy || process.env.https_proxy || process.env.http_proxy || null
     });
     debug('remote not set - defaulting to remotes\'s defaults');
   }


### PR DESCRIPTION
I was using the proxy feature of component (a node app _on a corporate network!_) but since version 1 this feature was removed and hasn't yet been added back in.

This is a one-line change to add support back for proxies.

Additionally I notice that Component itself needs to have [line 14 uncommented and line 12 removed](https://github.com/component/component/blob/master/bin/component-install#L14) so that people can specify the proxy manually if they wish.

Edit: This secure environment variables thing seems a little difficult. If I change them on my side to reflect my own repository it'll probably pass, but you wouldn't want to merge them in...
